### PR TITLE
Upgraded the maven-plugin-plugin to v3.3.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.2</version>
+        <version>3.3</version>
         <configuration>
           <goalPrefix>capsule</goalPrefix>
           <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>


### PR DESCRIPTION
(Otherwise, the build fails at the javadoc plugin phase because the HelpMojo.java generated is invalid for java8, this is only a java8 issue)
